### PR TITLE
右スティックを押し込んだときカメラが正面を向くように変更

### DIFF
--- a/Assets/Camera.meta
+++ b/Assets/Camera.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 926a27ba089d2644d90b1c0752214690
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Camera/CameraController.cs
+++ b/Assets/Camera/CameraController.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace RampageCars
+{
+    [RequireComponent(typeof(ICamera))]
+    public class CameraController : MonoBehaviour
+    {
+        PlayerAction action;
+        ICamera camera;
+
+        private void OnEnable()
+        {
+            action = new ();
+            action.Enable();
+        }
+
+        private void OnDisable()
+        {
+            action.Disable();
+        }
+
+        void Start()
+        {
+            camera = GetComponent<ICamera>();
+            action.Camera.Reset.started += ResetStarted;
+        }
+
+        private void ResetStarted(InputAction.CallbackContext obj)
+        {
+            camera.ViewReset();
+            Debug.Log("bb");
+        }
+    }
+}

--- a/Assets/Camera/CameraController.cs
+++ b/Assets/Camera/CameraController.cs
@@ -31,7 +31,6 @@ namespace RampageCars
         private void ResetStarted(InputAction.CallbackContext obj)
         {
             camera.ViewReset();
-            Debug.Log("bb");
         }
     }
 }

--- a/Assets/Camera/CameraController.cs.meta
+++ b/Assets/Camera/CameraController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0f05950d758010441b0ed721ba28eea2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Camera/CameraReset.cs
+++ b/Assets/Camera/CameraReset.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Cinemachine;
+
+namespace RampageCars
+{
+    public class CameraReset : MonoBehaviour, ICamera
+    {
+        CinemachineFreeLook cinemaFreeLook;
+        private int resetCount = 0;
+        void Awake()
+        {
+            cinemaFreeLook = this.GetComponent<CinemachineFreeLook>();
+        }
+
+        void Update()
+        {
+            if (resetCount >= 0) { resetCount--; }
+            else
+            {
+                cinemaFreeLook.m_RecenterToTargetHeading.m_enabled = false;
+                cinemaFreeLook.m_YAxisRecentering.m_enabled = false;
+            }
+            
+        }
+        public void ViewReset()
+        {
+            cinemaFreeLook.m_RecenterToTargetHeading.m_enabled=true;
+            cinemaFreeLook.m_YAxisRecentering.m_enabled = true;
+            resetCount = 30;
+            Debug.Log("aa");
+        }
+    }
+}

--- a/Assets/Camera/CameraReset.cs
+++ b/Assets/Camera/CameraReset.cs
@@ -12,6 +12,10 @@ namespace RampageCars
         void Awake()
         {
             cinemaFreeLook = this.GetComponent<CinemachineFreeLook>();
+            cinemaFreeLook.m_RecenterToTargetHeading.m_WaitTime = 0;
+            cinemaFreeLook.m_RecenterToTargetHeading.m_RecenteringTime = 0.1f;
+            cinemaFreeLook.m_YAxisRecentering.m_WaitTime = 0;
+            cinemaFreeLook.m_YAxisRecentering.m_RecenteringTime = 0.1f;
         }
 
         void Update()
@@ -29,7 +33,6 @@ namespace RampageCars
             cinemaFreeLook.m_RecenterToTargetHeading.m_enabled=true;
             cinemaFreeLook.m_YAxisRecentering.m_enabled = true;
             resetCount = 30;
-            Debug.Log("aa");
         }
     }
 }

--- a/Assets/Camera/CameraReset.cs
+++ b/Assets/Camera/CameraReset.cs
@@ -13,9 +13,9 @@ namespace RampageCars
         {
             cinemaFreeLook = this.GetComponent<CinemachineFreeLook>();
             cinemaFreeLook.m_RecenterToTargetHeading.m_WaitTime = 0;
-            cinemaFreeLook.m_RecenterToTargetHeading.m_RecenteringTime = 0.1f;
+            cinemaFreeLook.m_RecenterToTargetHeading.m_RecenteringTime = 0.04f;
             cinemaFreeLook.m_YAxisRecentering.m_WaitTime = 0;
-            cinemaFreeLook.m_YAxisRecentering.m_RecenteringTime = 0.1f;
+            cinemaFreeLook.m_YAxisRecentering.m_RecenteringTime = 0.04f;
         }
 
         void Update()

--- a/Assets/Camera/CameraReset.cs.meta
+++ b/Assets/Camera/CameraReset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3b34e108eaef27646a01738b1933a250
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Camera/ICamera.cs
+++ b/Assets/Camera/ICamera.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace RampageCars
+{
+    interface ICamera
+    {
+        void ViewReset();
+    }
+}

--- a/Assets/Camera/ICamera.cs.meta
+++ b/Assets/Camera/ICamera.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 234796cf7a0d69e4cae0e27c761bcc2b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Cars/ICar.cs
+++ b/Assets/Cars/ICar.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Assets/InputSystem.inputsettings.asset
+++ b/Assets/InputSystem.inputsettings.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c46f07b5ed07e4e92aa78254188d3d10, type: 3}
+  m_Name: InputSystem.inputsettings
+  m_EditorClassIdentifier: 
+  m_SupportedDevices: []
+  m_UpdateMode: 1
+  m_MaxEventBytesPerUpdate: 5242880
+  m_MaxQueuedEventsPerUpdate: 1000
+  m_CompensateForScreenOrientation: 1
+  m_FilterNoiseOnCurrent: 0
+  m_BackgroundBehavior: 0
+  m_EditorInputBehaviorInPlayMode: 0
+  m_DefaultDeadzoneMin: 0.125
+  m_DefaultDeadzoneMax: 0.925
+  m_DefaultButtonPressPoint: 0.5
+  m_ButtonReleaseThreshold: 0.75
+  m_DefaultTapTime: 0.2
+  m_DefaultSlowTapTime: 0.5
+  m_DefaultHoldTime: 0.4
+  m_TapRadius: 5
+  m_MultiTapDelayTime: 0.75
+  m_DisableRedundantEventsMerging: 0
+  m_iOSSettings:
+    m_MotionUsage:
+      m_Enabled: 0
+      m_Description: 

--- a/Assets/InputSystem.inputsettings.asset.meta
+++ b/Assets/InputSystem.inputsettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f327275dade111646ae567c1e0d7652f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Inputs/PlayerAction.cs
+++ b/Assets/Inputs/PlayerAction.cs
@@ -811,6 +811,45 @@ public partial class @PlayerAction : IInputActionCollection2, IDisposable
                     ""isPartOfComposite"": false
                 }
             ]
+        },
+        {
+            ""name"": ""Camera"",
+            ""id"": ""a0d7b540-0a2b-43b9-aaa2-19911fad0873"",
+            ""actions"": [
+                {
+                    ""name"": ""Reset"",
+                    ""type"": ""Button"",
+                    ""id"": ""8f0dc475-3305-467a-b97f-a99853989710"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                }
+            ],
+            ""bindings"": [
+                {
+                    ""name"": """",
+                    ""id"": ""63ccd2b6-069e-48cb-a26b-a97fa45366a9"",
+                    ""path"": ""<Gamepad>/rightStickPress"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Gamepad"",
+                    ""action"": ""Reset"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""0aff7474-011a-439f-919c-7cb1cbdf3762"",
+                    ""path"": ""<Keyboard>/r"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""Reset"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                }
+            ]
         }
     ],
     ""controlSchemes"": [
@@ -895,6 +934,9 @@ public partial class @PlayerAction : IInputActionCollection2, IDisposable
         m_UI_RightClick = m_UI.FindAction("RightClick", throwIfNotFound: true);
         m_UI_TrackedDevicePosition = m_UI.FindAction("TrackedDevicePosition", throwIfNotFound: true);
         m_UI_TrackedDeviceOrientation = m_UI.FindAction("TrackedDeviceOrientation", throwIfNotFound: true);
+        // Camera
+        m_Camera = asset.FindActionMap("Camera", throwIfNotFound: true);
+        m_Camera_Reset = m_Camera.FindAction("Reset", throwIfNotFound: true);
     }
 
     public void Dispose()
@@ -1120,6 +1162,39 @@ public partial class @PlayerAction : IInputActionCollection2, IDisposable
         }
     }
     public UIActions @UI => new UIActions(this);
+
+    // Camera
+    private readonly InputActionMap m_Camera;
+    private ICameraActions m_CameraActionsCallbackInterface;
+    private readonly InputAction m_Camera_Reset;
+    public struct CameraActions
+    {
+        private @PlayerAction m_Wrapper;
+        public CameraActions(@PlayerAction wrapper) { m_Wrapper = wrapper; }
+        public InputAction @Reset => m_Wrapper.m_Camera_Reset;
+        public InputActionMap Get() { return m_Wrapper.m_Camera; }
+        public void Enable() { Get().Enable(); }
+        public void Disable() { Get().Disable(); }
+        public bool enabled => Get().enabled;
+        public static implicit operator InputActionMap(CameraActions set) { return set.Get(); }
+        public void SetCallbacks(ICameraActions instance)
+        {
+            if (m_Wrapper.m_CameraActionsCallbackInterface != null)
+            {
+                @Reset.started -= m_Wrapper.m_CameraActionsCallbackInterface.OnReset;
+                @Reset.performed -= m_Wrapper.m_CameraActionsCallbackInterface.OnReset;
+                @Reset.canceled -= m_Wrapper.m_CameraActionsCallbackInterface.OnReset;
+            }
+            m_Wrapper.m_CameraActionsCallbackInterface = instance;
+            if (instance != null)
+            {
+                @Reset.started += instance.OnReset;
+                @Reset.performed += instance.OnReset;
+                @Reset.canceled += instance.OnReset;
+            }
+        }
+    }
+    public CameraActions @Camera => new CameraActions(this);
     private int m_KeyboardMouseSchemeIndex = -1;
     public InputControlScheme KeyboardMouseScheme
     {
@@ -1185,5 +1260,9 @@ public partial class @PlayerAction : IInputActionCollection2, IDisposable
         void OnRightClick(InputAction.CallbackContext context);
         void OnTrackedDevicePosition(InputAction.CallbackContext context);
         void OnTrackedDeviceOrientation(InputAction.CallbackContext context);
+    }
+    public interface ICameraActions
+    {
+        void OnReset(InputAction.CallbackContext context);
     }
 }

--- a/Assets/Inputs/PlayerAction.inputactions
+++ b/Assets/Inputs/PlayerAction.inputactions
@@ -789,6 +789,45 @@
                     "isPartOfComposite": false
                 }
             ]
+        },
+        {
+            "name": "Camera",
+            "id": "a0d7b540-0a2b-43b9-aaa2-19911fad0873",
+            "actions": [
+                {
+                    "name": "Reset",
+                    "type": "Button",
+                    "id": "8f0dc475-3305-467a-b97f-a99853989710",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "63ccd2b6-069e-48cb-a26b-a97fa45366a9",
+                    "path": "<Gamepad>/rightStickPress",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Reset",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "0aff7474-011a-439f-919c-7cb1cbdf3762",
+                    "path": "<Keyboard>/r",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Reset",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
         }
     ],
     "controlSchemes": [


### PR DESCRIPTION
## Issueへのリンク
* https://github.com/Shi-553/RampageCars/issues/33

## やったこと
* 右スティックまたはRキー押し込みで車の正面を向くように

## やらないこと
* 

## その他
* VirtualCameraにCameraフォルダに入ってある「CameraController」と「CameraReset」をアタッチしたら動きます。(Prefab化しようとしたらおかしなことになったのでこのような形に...)