### PR TITLE
NotNull属性の実装

### DIFF
--- a/Assets/Audio/HitAudio.cs
+++ b/Assets/Audio/HitAudio.cs
@@ -1,14 +1,15 @@
 using System.Collections;
 using System.Collections.Generic;
+using EditorScripts;
 using UnityEngine;
 
 namespace RampageCars
 {
     public class HitAudio : MonoEventReceiver
     {
-        [SerializeField]
+        [SerializeField, NotNull]
         AudioClip hit;
-        [SerializeField]
+        [SerializeField, NotNull]
         AudioClip explosion;
 
 

--- a/Assets/EditorScripts/DragDrop/DragDropAttribute.cs
+++ b/Assets/EditorScripts/DragDrop/DragDropAttribute.cs
@@ -2,16 +2,16 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace DragDrop {
+namespace EditorScripts {
     /// <summary>
-    /// ���̎��̃v���p�e�B��Ώۂɂ���
+    /// この次のプロパティを対象にする
     /// </summary>
     [Serializable]
     public class DammyNextDragDropProperty {
     }
 
     /// <summary>
-    /// �ʂ̒l����h���b�N&�h���b�v��SerializeReference��ݒ肷�邽�߂̑���
+    /// 別の値からドラック&ドロップでSerializeReferenceを設定するための属性
     /// </summary>
     [AttributeUsage(AttributeTargets.Field, AllowMultiple = true)]
     public class SubclassFromOtherDragDropAttribute : PropertyAttribute {
@@ -26,7 +26,7 @@ namespace DragDrop {
 
 
     /// <summary>
-    /// �h���b�N&�h���b�v�Ńp�X��ݒ肷�邽�߂̑���
+    /// ドラック&ドロップでパスを設定するための属性
     /// </summary>
     public class PathDragDropAttribute : PropertyAttribute {
     }

--- a/Assets/EditorScripts/DragDrop/Editor/DragDropDrawer.cs
+++ b/Assets/EditorScripts/DragDrop/Editor/DragDropDrawer.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
-namespace DragDrop {
+namespace EditorScripts {
     public class DragDropDrawerBase : PropertyDrawer {
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label) {
             var isDammy = fieldInfo.FieldType == typeof(DammyNextDragDropProperty);

--- a/Assets/EditorScripts/NotNull.meta
+++ b/Assets/EditorScripts/NotNull.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: abae5b91348747a4088f3e63b9ecd75f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/EditorScripts/NotNull/Editor.meta
+++ b/Assets/EditorScripts/NotNull/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 15e3c6341280dee43a1a6adb31a7fd84
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/EditorScripts/NotNull/Editor/DisallowPlayModeIfNull.cs
+++ b/Assets/EditorScripts/NotNull/Editor/DisallowPlayModeIfNull.cs
@@ -41,7 +41,7 @@ namespace UnityEditor
                         var fieldName = ObjectNames.NicifyVariableName(field.Name);
                         var className = ObjectNames.NicifyVariableName(component.GetType().Name);
 
-                        string message = $"<b>{component.name}</b> in <b>{className}</b> in <b>{fieldName}</b> is null!";
+                        string message = $"<b>{component.name}</b> -> <b>{className}</b> -> <b>{fieldName}</b> is null!";
 
                         // こうするとダブルクリックしてもこの行に飛ばない
                         Debug.unityLogger.logHandler.LogFormat(LogType.Error, component, message);

--- a/Assets/EditorScripts/NotNull/Editor/DisallowPlayModeIfNull.cs
+++ b/Assets/EditorScripts/NotNull/Editor/DisallowPlayModeIfNull.cs
@@ -1,0 +1,58 @@
+using UnityEngine;
+using System.Reflection;
+using EditorScripts;
+
+namespace UnityEditor
+{
+    [InitializeOnLoad]
+    public static class DisallowPlayModeIfNull
+    {
+        static DisallowPlayModeIfNull()
+        {
+            EditorApplication.playModeStateChanged += LogNullError;
+        }
+
+        private static void LogNullError(PlayModeStateChange state)
+        {
+            if (state != PlayModeStateChange.ExitingEditMode)
+            {
+                return;
+            }
+
+            bool isError = false;
+
+            foreach (var component in GameObject.FindObjectsOfType<Component>(true))
+            {
+                foreach (var field in component.GetType().GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+                {
+                    var attribute = field.GetCustomAttribute<NotNullAttribute>(true);
+
+                    if (attribute is null)
+                    {
+                        continue;
+                    }
+                    var val = field.GetValue(component);
+
+                    // 真のnullと偽装nullで2重チェック
+                    if (val == null || (UnityEngine.Object)val == null)
+                    {
+                        isError = true;
+
+                        var fieldName = ObjectNames.NicifyVariableName(field.Name);
+                        var className = ObjectNames.NicifyVariableName(component.GetType().Name);
+
+                        string message = $"<b>{component.name}</b> in <b>{className}</b> in <b>{fieldName}</b> is null!";
+
+                        // こうするとダブルクリックしてもこの行に飛ばない
+                        Debug.unityLogger.logHandler.LogFormat(LogType.Error, component, message);
+                    }
+                }
+            }
+
+            if (isError)
+            {
+                EditorApplication.ExitPlaymode();
+            }
+        }
+    }
+}

--- a/Assets/EditorScripts/NotNull/Editor/DisallowPlayModeIfNull.cs.meta
+++ b/Assets/EditorScripts/NotNull/Editor/DisallowPlayModeIfNull.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 37a7f25782506e14f9558a0f6fb47f40
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/EditorScripts/NotNull/Editor/NotNullDrawer.cs
+++ b/Assets/EditorScripts/NotNull/Editor/NotNullDrawer.cs
@@ -1,62 +1,8 @@
 using UnityEngine;
-using System.Reflection;
 using EditorScripts;
 
 namespace UnityEditor
 {
-
-    [InitializeOnLoad]
-    public static class DisallowPlayModeIfNull
-    {
-        static DisallowPlayModeIfNull()
-        {
-            EditorApplication.playModeStateChanged += LogNullError;
-        }
-
-        private static void LogNullError(PlayModeStateChange state)
-        {
-            if (state != PlayModeStateChange.ExitingEditMode)
-            {
-                return;
-            }
-
-            bool isError = false;
-
-            foreach (var component in GameObject.FindObjectsOfType<Component>(true))
-            {
-                foreach (var field in component.GetType().GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
-                {
-                    var attribute = field.GetCustomAttribute<NotNullAttribute>(true);
-
-                    if (attribute is null)
-                    {
-                        continue;
-                    }
-                    var val = field.GetValue(component);
-
-                    // 真のnullと偽装nullで2重チェック
-                    if (val == null || (UnityEngine.Object)val == null)
-                    {
-                        isError = true;
-
-                        var fieldName = ObjectNames.NicifyVariableName(field.Name);
-                        var className = ObjectNames.NicifyVariableName(component.GetType().Name);
-
-                        string message = $"<b>{component.name}</b> in <b>{className}</b> in <b>{fieldName}</b> is null!";
-
-                        // こうするとダブルクリックしてもこの行に飛ばない
-                        Debug.unityLogger.logHandler.LogFormat(LogType.Error, component, message);
-                    }
-                }
-            }
-
-            if (isError)
-            {
-                EditorApplication.ExitPlaymode();
-            }
-        }
-    }
-
     // 参考
     // https://hacchi-man.hatenablog.com/entry/2021/01/01/220000
     [CustomPropertyDrawer(typeof(NotNullAttribute))]

--- a/Assets/EditorScripts/NotNull/Editor/NotNullDrawer.cs
+++ b/Assets/EditorScripts/NotNull/Editor/NotNullDrawer.cs
@@ -40,7 +40,7 @@ namespace UnityEditor
                         isError = true;
 
                         var fieldName = ObjectNames.NicifyVariableName(field.Name);
-                        var className = ObjectNames.GetClassName(component);
+                        var className = ObjectNames.NicifyVariableName(component.GetType().Name);
 
                         string message = $"<b>{component.name}</b> in <b>{className}</b> in <b>{fieldName}</b> is null!";
 
@@ -57,6 +57,8 @@ namespace UnityEditor
         }
     }
 
+    // 参考
+    // https://hacchi-man.hatenablog.com/entry/2021/01/01/220000
     [CustomPropertyDrawer(typeof(NotNullAttribute))]
     public class NotNullDrawer : PropertyDrawer
     {

--- a/Assets/EditorScripts/NotNull/Editor/NotNullDrawer.cs
+++ b/Assets/EditorScripts/NotNull/Editor/NotNullDrawer.cs
@@ -1,0 +1,94 @@
+using UnityEngine;
+using System.Reflection;
+using EditorScripts;
+
+namespace UnityEditor
+{
+
+    [InitializeOnLoad]
+    public static class DisallowPlayModeIfNull
+    {
+        static DisallowPlayModeIfNull()
+        {
+            EditorApplication.playModeStateChanged += LogNullError;
+        }
+
+        private static void LogNullError(PlayModeStateChange state)
+        {
+            if (state != PlayModeStateChange.ExitingEditMode)
+            {
+                return;
+            }
+
+            bool isError = false;
+
+            foreach (var component in GameObject.FindObjectsOfType<Component>(true))
+            {
+                foreach (var field in component.GetType().GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+                {
+                    var attribute = field.GetCustomAttribute<NotNullAttribute>(true);
+
+                    if (attribute is null)
+                    {
+                        continue;
+                    }
+                    var val = field.GetValue(component);
+
+                    // 真のnullと偽装nullで2重チェック
+                    if (val == null || (UnityEngine.Object)val == null)
+                    {
+                        isError = true;
+
+                        var fieldName = ObjectNames.NicifyVariableName(field.Name);
+                        var className = ObjectNames.GetClassName(component);
+
+                        string message = $"<b>{component.name}</b> in <b>{className}</b> in <b>{fieldName}</b> is null!";
+
+                        // こうするとダブルクリックしてもこの行に飛ばない
+                        Debug.unityLogger.logHandler.LogFormat(LogType.Error, component, message);
+                    }
+                }
+            }
+
+            if (isError)
+            {
+                EditorApplication.ExitPlaymode();
+            }
+        }
+    }
+
+    [CustomPropertyDrawer(typeof(NotNullAttribute))]
+    public class NotNullDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            position.height = base.GetPropertyHeight(property, label);
+            EditorGUI.PropertyField(position, property, label);
+            position.y += position.height;
+            if (IsRequire(property))
+            {
+                EditorGUI.HelpBox(position, "Set Value", MessageType.Error);
+            }
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            if (IsRequire(property))
+            {
+                return base.GetPropertyHeight(property, label) * 2f;
+            }
+            return base.GetPropertyHeight(property, label);
+        }
+
+        private bool IsRequire(SerializedProperty property)
+        {
+            switch (property.propertyType)
+            {
+                case SerializedPropertyType.ObjectReference:
+                    return property.objectReferenceValue == null;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Assets/EditorScripts/NotNull/Editor/NotNullDrawer.cs.meta
+++ b/Assets/EditorScripts/NotNull/Editor/NotNullDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2edca14655d30094fbd2fe52fec7e6c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/EditorScripts/NotNull/NotNullAttribute.cs
+++ b/Assets/EditorScripts/NotNull/NotNullAttribute.cs
@@ -3,7 +3,6 @@ using System;
 
 namespace EditorScripts
 {
-    // https://hacchi-man.hatenablog.com/entry/2021/01/01/220000
     [AttributeUsage(AttributeTargets.Field)]
     public class NotNullAttribute : PropertyAttribute
     {

--- a/Assets/EditorScripts/NotNull/NotNullAttribute.cs
+++ b/Assets/EditorScripts/NotNull/NotNullAttribute.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+using System;
+
+namespace EditorScripts
+{
+    // https://hacchi-man.hatenablog.com/entry/2021/01/01/220000
+    [AttributeUsage(AttributeTargets.Field)]
+    public class NotNullAttribute : PropertyAttribute
+    {
+    }
+}

--- a/Assets/EditorScripts/NotNull/NotNullAttribute.cs.meta
+++ b/Assets/EditorScripts/NotNull/NotNullAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56cb991de76f5af4fbb1c3d050f98abc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/EditorScripts/SubclassSelector/Editor/SubclassSelectorDrawer.cs
+++ b/Assets/EditorScripts/SubclassSelector/Editor/SubclassSelectorDrawer.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using UnityEngine;
 using UnityEditor;
 
-namespace SubclassSelector {
+namespace EditorScripts {
     [CustomPropertyDrawer(typeof(SubclassSelectorAttribute))]
     public class SubclassSelectorDrawer : PropertyDrawer {
         bool initialized = false;

--- a/Assets/EditorScripts/SubclassSelector/SubclassSelectorAttribute.cs
+++ b/Assets/EditorScripts/SubclassSelector/SubclassSelectorAttribute.cs
@@ -1,7 +1,7 @@
 using System;
 using UnityEngine;
 
-namespace SubclassSelector {
+namespace EditorScripts {
     [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
     public class SubclassSelectorAttribute : PropertyAttribute {
         private bool m_includeMono;

--- a/Assets/Effects/Script/ContactEffect.cs
+++ b/Assets/Effects/Script/ContactEffect.cs
@@ -1,15 +1,15 @@
 using System.Collections;
 using System.Collections.Generic;
+using EditorScripts;
 using UnityEngine;
 
 namespace RampageCars
 {
-
     public class ContactEffect : MonoEventReceiver
     {
-        [SerializeField]
+        [SerializeField, NotNull]
         GameObject hit;
-        [SerializeField]
+        [SerializeField, NotNull]
         GameObject explosion;
 
         private void Start()

--- a/Assets/Enemys/TestEnemySponer.cs
+++ b/Assets/Enemys/TestEnemySponer.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using EditorScripts;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 
@@ -9,7 +10,7 @@ namespace RampageCars
 {
     public class TestEnemySponer : MonoBehaviour
     {
-        [SerializeField]
+        [SerializeField, NotNull]
         GameObject testEnemy;
 
         float time;


### PR DESCRIPTION
## Issueへのリンク
なし

## やったこと
* `SerializeField`なのにセットされていないときにエラーを出す`EditorScripts.NotNull`属性を作った。
* セットしないとエラーが出てプレイできないようにした。

## その他
* テスト方法: `TestEnemySponer`の`TestEnemy`プレハブの参照を`null`にしてエディタを再生するとエラーがでる。
